### PR TITLE
Add support for filtering app_id based on APP_ID_REGEX env variable

### DIFF
--- a/src/main/scala/com/snowplowanalytics/indicative/LambdaHandler.scala
+++ b/src/main/scala/com/snowplowanalytics/indicative/LambdaHandler.scala
@@ -14,6 +14,7 @@ package com.snowplowanalytics.indicative
 
 // Scala
 import scala.collection.JavaConverters._
+import scala.util.matching.Regex
 
 // cats
 import cats.data.EitherT
@@ -36,6 +37,7 @@ class LambdaHandler {
     sys.env.getOrElse("INDICATIVE_API_KEY",
                       throw new RuntimeException("You must provide environment variable INDICATIVE_API_KEY"))
   val indicativeBatchSize = 100
+  val appIdPattern: Regex = sys.env.getOrElse("APP_ID_REGEX", ".%").r
 
   def recordHandler(event: KinesisEvent): Unit = {
     val events: List[Either[TransformationError, JsonObject]] = event.getRecords.asScala
@@ -52,7 +54,7 @@ class LambdaHandler {
             EventTransformer
               .transformWithInventory(dataArray)
               .leftMap(errors => TransformationError(errors.mkString("\n  * "))))
-          indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory))
+          indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory, appIdPattern))
         } yield indicativeEvent).value
       }
       .toList

--- a/src/main/scala/com/snowplowanalytics/indicative/Transformer.scala
+++ b/src/main/scala/com/snowplowanalytics/indicative/Transformer.scala
@@ -27,6 +27,9 @@ import io.circe.parser.parse
 // Analytics SDK
 import com.snowplowanalytics.snowplow.analytics.scalasdk.json.Data.InventoryItem
 
+// Scala
+import scala.util.matching.Regex
+
 /**
  * Contains functions for transforming Snowplow JSON into Indicative JSON. Outputs do not include the apiKey field.
  */
@@ -40,41 +43,49 @@ object Transformer {
    * Transforms Snowplow enriched event string into Indicative event format
    * @param snowplowEvent Snowplow enriched event JSON string
    * @param inventory a set of inventory items returned by EventTransformer
+   * @param appIdPattern Regex for matching app_ids that should be sent to Indicative
    * @return either an error or a JsonObject containing Indicative event
    */
   def transform(
     snowplowEvent: String,
-    inventory: Set[InventoryItem]
+    inventory: Set[InventoryItem],
+    appIdPattern: Regex
   ): Option[Either[TransformationError, JsonObject]] =
     (for {
       snowplowEvent <- EitherT
         .fromEither[Option](parse(snowplowEvent).leftMap(e => TransformationError(e.message)))
-      indicativeEvent <- EitherT(snowplowJsonToIndicativeEvent(snowplowEvent, inventory))
+      indicativeEvent <- EitherT(snowplowJsonToIndicativeEvent(snowplowEvent, inventory, appIdPattern))
     } yield indicativeEvent).value
 
   /**
    * Turns a Snowplow enriched event in a json format into a json ready do be consumed by Indicative.
    * @param snowplowJson Snowplow enriched event in a json format
    * @param inventory a set of inventory items returned by EventTransformer
+   * @param appIdPattern Regex for matching app_ids that should be sent to Indicative
    * @return None if the event doesn't contain a user identifying field (user_id,
-   * client_session_user_id, or domain_userid). Otherwise, it returns either an event in Indicative
+   * client_session_user_id, or domain_userid), or if the app_id for the event doesn't
+   * match the provided Regex. Otherwise, it returns either an event in Indicative
    * format or a transformation error.
    */
   def snowplowJsonToIndicativeEvent(snowplowJson: Json,
-                                    inventory: Set[InventoryItem]): Option[Either[TransformationError, JsonObject]] = {
+                                    inventory: Set[InventoryItem],
+                                    appIdPattern: Regex): Option[Either[TransformationError, JsonObject]] = {
     val properties = flattenJson(snowplowJson, inventory)
     val eventName  = extractField(properties, "event_name")
+    val appId = extractField(properties, "app_id").toOption
+      .flatMap(appIdPattern.findFirstMatchIn)
     val userId = extractField(properties, "user_id")
       .leftFlatMap(_ => extractField(properties, "client_session_user_id"))
       .leftFlatMap(_ => extractField(properties, "domain_userid"))
       .toOption
-
     val eventTime = extractField(properties, "derived_tstamp").flatMap(timestampToMillis)
 
-    userId.map { uid =>
-      (eventName, properties.asRight[TransformationError], eventTime)
-        .mapN { case (eName, props, eTime) => constructIndicativeJson(eName, uid, props, eTime) }
-        .leftMap(decodingError => TransformationError(decodingError.message))
+    appId.flatMap { _ =>
+      (userId.map { uid =>
+        (eventName, properties.asRight[TransformationError], eventTime)
+          .mapN { case (eName, props, eTime) => constructIndicativeJson(eName, uid, props, eTime) }
+          .leftMap(decodingError => TransformationError(decodingError.message))
+      })
     }
   }
 

--- a/src/test/scala/com/snowplowanalytics/indicative/TransformationSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/indicative/TransformationSpec.scala
@@ -30,14 +30,198 @@ class TransformationSpec extends Specification with ScalaCheck with Matchers {
   def is = s2"""
 
     integration test                                                $e1
-    integration test without user identifying property              $e2
-    should be transformed with real contexts generated from schemas $e3
-    flattenJson should work on empty arrays                         $e4
-    flattenJson should work on empty objects                        $e5
+    integration test matching app_id                                $e2
+    integration test non-matching app_id                            $e3
+    integration test matching regex app_id                          $e4
+    integration test non-matching regex app_id                      $e5
+    integration test without user identifying property              $e6
+    should be transformed with real contexts generated from schemas $e7
+    flattenJson should work on empty arrays                         $e8
+    flattenJson should work on empty objects                        $e9
 
   """
 
   val apiKey = "API_KEY"
+
+  val expected = json"""
+    {
+      "eventName": "link_click_test",
+      "eventUniqueId": "jon.doe@email.com",
+      "eventTime": 1532217837886,
+      "properties": {
+        "page_urlhost" : "www.snowplowanalytics.com",
+        "br_features_realplayer" : null,
+        "etl_tstamp" : "2018-07-20T00:01:25.292Z",
+        "web_page_inLanguage" : "en-US",
+        "dvce_ismobile" : null,
+        "geo_latitude" : 37.443604,
+        "performance_timing_domContentLoadedEventEnd" : 1415358091309,
+        "refr_medium" : null,
+        "performance_timing_domainLookupStart" : 1415358090102,
+        "ti_orderid" : null,
+        "br_version" : null,
+        "base_currency" : null,
+        "v_collector" : "clj-tomcat-0.1.0",
+        "mkt_content" : null,
+        "collector_tstamp" : "2018-07-20T00:02:05Z",
+        "os_family" : null,
+        "performance_timing_unloadEventEnd" : 1415358090287,
+        "ti_sku" : null,
+        "event_vendor" : "com.snowplowanalytics.snowplow",
+        "network_userid" : "ecdff4d0-9175-40ac-a8bb-325c49733607",
+        "performance_timing_requestStart" : 1415358090183,
+        "br_renderengine" : null,
+        "br_lang" : null,
+        "tr_affiliation" : null,
+        "ti_quantity" : null,
+        "ti_currency" : null,
+        "geo_country" : "US",
+        "user_fingerprint" : "2161814971",
+        "performance_timing_responseStart" : 1415358090265,
+        "mkt_medium" : null,
+        "page_urlscheme" : "http",
+        "ua_parser_context_osMinor" : null,
+        "ti_category" : null,
+        "ua_parser_context_useragentFamily" : "IE",
+        "pp_yoffset_min" : null,
+        "br_features_quicktime" : null,
+        "event" : "page_view",
+        "refr_urlhost" : null,
+        "user_ipaddress" : "92.231.54.234",
+        "br_features_pdf" : true,
+        "page_referrer" : null,
+        "ua_parser_context_useragentPatch" : null,
+        "doc_height" : null,
+        "refr_urlscheme" : null,
+        "performance_timing_redirectStart" : 0,
+        "geo_region" : "TX",
+        "geo_timezone" : null,
+        "page_urlfragment" : "4-conclusion",
+        "br_features_flash" : false,
+        "os_manufacturer" : null,
+        "mkt_clickid" : null,
+        "ti_price" : null,
+        "br_colordepth" : null,
+        "web_page_author" : "Fred Blundun",
+        "event_format" : "jsonschema",
+        "tr_total" : null,
+        "pp_xoffset_min" : null,
+        "doc_width" : null,
+        "geo_zipcode" : "94109",
+        "br_family" : null,
+        "web_page_datePublished" : "2014-11-06T00:00:00Z",
+        "tr_currency" : null,
+        "web_page_breadcrumb" : "blog",
+        "useragent" : null,
+        "event_name" : "link_click_test",
+        "os_name" : null,
+        "page_urlpath" : "/product/index.html",
+        "br_name" : null,
+        "ip_netspeed" : "Cable/DSL",
+        "page_title" : "On Analytics",
+        "performance_timing_navigationStart" : 1415358089861,
+        "ip_organization" : "Bouygues Telecom",
+        "performance_timing_domInteractive" : 1415358090886,
+        "dvce_created_tstamp" : "2018-07-20T00:03:57.885Z",
+        "br_features_gears" : null,
+        "dvce_type" : null,
+        "dvce_sent_tstamp" : null,
+        "se_action" : null,
+        "br_features_director" : null,
+        "performance_timing_domComplete" : 0,
+        "se_category" : null,
+        "ti_name" : null,
+        "user_id" : "jon.doe@email.com",
+        "performance_timing_unloadEventStart" : 1415358090270,
+        "refr_urlquery" : null,
+        "ua_parser_context_useragentVersion" : "IE 7.0",
+        "performance_timing_loadEventStart" : 0,
+        "performance_timing_domLoading" : 1415358090270,
+        "true_tstamp" : "2018-07-23T00:03:57.886Z",
+        "geo_longitude" : -122.4124,
+        "mkt_term" : null,
+        "v_tracker" : "js-2.1.0",
+        "os_timezone" : null,
+        "br_type" : null,
+        "br_features_windowsmedia" : null,
+        "link_click_targetUrl" : "http://www.example.com",
+        "event_version" : "1-0-0",
+        "ua_parser_context_useragentMajor" : "7",
+        "dvce_screenwidth" : null,
+        "se_label" : null,
+        "domain_sessionid" : "2b15e5c8-d3b1-11e4-b9d6-1681e6b88ec1",
+        "performance_timing_connectStart" : 1415358090103,
+        "performance_timing_fetchStart" : 1415358089870,
+        "domain_userid" : "bc2e92ec6c204a14",
+        "page_urlquery" : "id=GTM-DLRG",
+        "geo_location" : "37.443604,-122.4124",
+        "refr_term" : null,
+        "refr_device_tstamp" : null,
+        "link_click_elementClasses" : "foreground",
+        "link_click_elementId" : "exampleLink",
+        "name_tracker" : "cloudfront-1",
+        "ua_parser_context_useragentMinor" : "0",
+        "tr_tax_base" : null,
+        "web_page_keywords" : "snowplow",
+        "dvce_screenheight" : null,
+        "mkt_campaign" : null,
+        "refr_urlfragment" : null,
+        "performance_timing_domContentLoadedEventStart" : 1415358090968,
+        "tr_shipping" : null,
+        "tr_shipping_base" : null,
+        "br_features_java" : null,
+        "br_viewwidth" : null,
+        "geo_city" : "New York",
+        "web_page_genre" : "blog",
+        "br_viewheight" : null,
+        "refr_domain_userid" : null,
+        "br_features_silverlight" : null,
+        "ti_price_base" : null,
+        "tr_tax" : null,
+        "br_cookies" : null,
+        "tr_total_base" : null,
+        "refr_urlport" : null,
+        "derived_tstamp" : "2018-07-22T00:03:57.886Z",
+        "app_id" : "angry-birds",
+        "ip_isp" : "FDN Communications",
+        "ua_parser_context_deviceFamily" : "Other",
+        "geo_region_name" : "Florida",
+        "ua_parser_context_osPatch" : null,
+        "pp_yoffset_max" : null,
+        "ip_domain" : "nuvox.net",
+        "performance_timing_connectEnd" : 1415358090183,
+        "domain_sessionidx" : 3,
+        "pp_xoffset_max" : null,
+        "mkt_source" : null,
+        "page_urlport" : 80,
+        "se_property" : null,
+        "platform" : "web",
+        "ua_parser_context_osFamily" : "Windows XP",
+        "performance_timing_loadEventEnd" : 0,
+        "event_id" : "c6124-b53a-4b13-a233-0088f79dcbcb",
+        "refr_urlpath" : null,
+        "mkt_network" : null,
+        "performance_timing_redirectEnd" : 0,
+        "ua_parser_context_osMajor" : null,
+        "ua_parser_context_osPatchMinor" : null,
+        "ua_parser_context_osVersion" : "Windows XP",
+        "performance_timing_domainLookupEnd" : 1415358090102,
+        "se_value" : null,
+        "page_url" : "http://www.snowplowanalytics.com",
+        "etl_tags" : null,
+        "tr_orderid" : null,
+        "tr_state" : null,
+        "txn_id" : 41828,
+        "performance_timing_responseEnd" : 1415358090265,
+        "refr_source" : null,
+        "tr_country" : null,
+        "tr_city" : null,
+        "doc_charset" : null,
+        "event_fingerprint" : "e3dbfa9cca0412c3d4052863cefb547f",
+        "v_etl" : "serde-0.5.2"
+      }
+    }
+  """
 
   def runTest(uri: String) = {
     val (gen, _) = Utils.fetch(uri)
@@ -60,7 +244,7 @@ class TransformationSpec extends Specification with ScalaCheck with Matchers {
           EventTransformer
             .transformWithInventory(str)
             .leftMap(errors => TransformationError(errors.mkString("\n  * "))))
-        indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory))
+        indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory, ".*".r))
       } yield indicativeEvent).value
 
       result must beSome and (result.map(_ must beRight).get)
@@ -69,192 +253,12 @@ class TransformationSpec extends Specification with ScalaCheck with Matchers {
 
   def e1 = {
 
-    val expected = json"""
-      {
-        "eventName": "link_click_test",
-        "eventUniqueId": "jon.doe@email.com",
-        "eventTime": 1532217837886,
-        "properties": {
-           "page_urlhost" : "www.snowplowanalytics.com",
-           "br_features_realplayer" : null,
-           "etl_tstamp" : "2018-07-20T00:01:25.292Z",
-           "web_page_inLanguage" : "en-US",
-           "dvce_ismobile" : null,
-           "geo_latitude" : 37.443604,
-           "performance_timing_domContentLoadedEventEnd" : 1415358091309,
-           "refr_medium" : null,
-           "performance_timing_domainLookupStart" : 1415358090102,
-           "ti_orderid" : null,
-           "br_version" : null,
-           "base_currency" : null,
-           "v_collector" : "clj-tomcat-0.1.0",
-           "mkt_content" : null,
-           "collector_tstamp" : "2018-07-20T00:02:05Z",
-           "os_family" : null,
-           "performance_timing_unloadEventEnd" : 1415358090287,
-           "ti_sku" : null,
-           "event_vendor" : "com.snowplowanalytics.snowplow",
-           "network_userid" : "ecdff4d0-9175-40ac-a8bb-325c49733607",
-           "performance_timing_requestStart" : 1415358090183,
-           "br_renderengine" : null,
-           "br_lang" : null,
-           "tr_affiliation" : null,
-           "ti_quantity" : null,
-           "ti_currency" : null,
-           "geo_country" : "US",
-           "user_fingerprint" : "2161814971",
-           "performance_timing_responseStart" : 1415358090265,
-           "mkt_medium" : null,
-           "page_urlscheme" : "http",
-           "ua_parser_context_osMinor" : null,
-           "ti_category" : null,
-           "ua_parser_context_useragentFamily" : "IE",
-           "pp_yoffset_min" : null,
-           "br_features_quicktime" : null,
-           "event" : "page_view",
-           "refr_urlhost" : null,
-           "user_ipaddress" : "92.231.54.234",
-           "br_features_pdf" : true,
-           "page_referrer" : null,
-           "ua_parser_context_useragentPatch" : null,
-           "doc_height" : null,
-           "refr_urlscheme" : null,
-           "performance_timing_redirectStart" : 0,
-           "geo_region" : "TX",
-           "geo_timezone" : null,
-           "page_urlfragment" : "4-conclusion",
-           "br_features_flash" : false,
-           "os_manufacturer" : null,
-           "mkt_clickid" : null,
-           "ti_price" : null,
-           "br_colordepth" : null,
-           "web_page_author" : "Fred Blundun",
-           "event_format" : "jsonschema",
-           "tr_total" : null,
-           "pp_xoffset_min" : null,
-           "doc_width" : null,
-           "geo_zipcode" : "94109",
-           "br_family" : null,
-           "web_page_datePublished" : "2014-11-06T00:00:00Z",
-           "tr_currency" : null,
-           "web_page_breadcrumb" : "blog",
-           "useragent" : null,
-           "event_name" : "link_click_test",
-           "os_name" : null,
-           "page_urlpath" : "/product/index.html",
-           "br_name" : null,
-           "ip_netspeed" : "Cable/DSL",
-           "page_title" : "On Analytics",
-           "performance_timing_navigationStart" : 1415358089861,
-           "ip_organization" : "Bouygues Telecom",
-           "performance_timing_domInteractive" : 1415358090886,
-           "dvce_created_tstamp" : "2018-07-20T00:03:57.885Z",
-           "br_features_gears" : null,
-           "dvce_type" : null,
-           "dvce_sent_tstamp" : null,
-           "se_action" : null,
-           "br_features_director" : null,
-           "performance_timing_domComplete" : 0,
-           "se_category" : null,
-           "ti_name" : null,
-           "user_id" : "jon.doe@email.com",
-           "performance_timing_unloadEventStart" : 1415358090270,
-           "refr_urlquery" : null,
-           "ua_parser_context_useragentVersion" : "IE 7.0",
-           "performance_timing_loadEventStart" : 0,
-           "performance_timing_domLoading" : 1415358090270,
-           "true_tstamp" : "2018-07-23T00:03:57.886Z",
-           "geo_longitude" : -122.4124,
-           "mkt_term" : null,
-           "v_tracker" : "js-2.1.0",
-           "os_timezone" : null,
-           "br_type" : null,
-           "br_features_windowsmedia" : null,
-           "link_click_targetUrl" : "http://www.example.com",
-           "event_version" : "1-0-0",
-           "ua_parser_context_useragentMajor" : "7",
-           "dvce_screenwidth" : null,
-           "se_label" : null,
-           "domain_sessionid" : "2b15e5c8-d3b1-11e4-b9d6-1681e6b88ec1",
-           "performance_timing_connectStart" : 1415358090103,
-           "performance_timing_fetchStart" : 1415358089870,
-           "domain_userid" : "bc2e92ec6c204a14",
-           "page_urlquery" : "id=GTM-DLRG",
-           "geo_location" : "37.443604,-122.4124",
-           "refr_term" : null,
-           "refr_device_tstamp" : null,
-           "link_click_elementClasses" : "foreground",
-           "link_click_elementId" : "exampleLink",
-           "name_tracker" : "cloudfront-1",
-           "ua_parser_context_useragentMinor" : "0",
-           "tr_tax_base" : null,
-           "web_page_keywords" : "snowplow",
-           "dvce_screenheight" : null,
-           "mkt_campaign" : null,
-           "refr_urlfragment" : null,
-           "performance_timing_domContentLoadedEventStart" : 1415358090968,
-           "tr_shipping" : null,
-           "tr_shipping_base" : null,
-           "br_features_java" : null,
-           "br_viewwidth" : null,
-           "geo_city" : "New York",
-           "web_page_genre" : "blog",
-           "br_viewheight" : null,
-           "refr_domain_userid" : null,
-           "br_features_silverlight" : null,
-           "ti_price_base" : null,
-           "tr_tax" : null,
-           "br_cookies" : null,
-           "tr_total_base" : null,
-           "refr_urlport" : null,
-           "derived_tstamp" : "2018-07-22T00:03:57.886Z",
-           "app_id" : "angry-birds",
-           "ip_isp" : "FDN Communications",
-           "ua_parser_context_deviceFamily" : "Other",
-           "geo_region_name" : "Florida",
-           "ua_parser_context_osPatch" : null,
-           "pp_yoffset_max" : null,
-           "ip_domain" : "nuvox.net",
-           "performance_timing_connectEnd" : 1415358090183,
-           "domain_sessionidx" : 3,
-           "pp_xoffset_max" : null,
-           "mkt_source" : null,
-           "page_urlport" : 80,
-           "se_property" : null,
-           "platform" : "web",
-           "ua_parser_context_osFamily" : "Windows XP",
-           "performance_timing_loadEventEnd" : 0,
-           "event_id" : "c6124-b53a-4b13-a233-0088f79dcbcb",
-           "refr_urlpath" : null,
-           "mkt_network" : null,
-           "performance_timing_redirectEnd" : 0,
-           "ua_parser_context_osMajor" : null,
-           "ua_parser_context_osPatchMinor" : null,
-           "ua_parser_context_osVersion" : "Windows XP",
-           "performance_timing_domainLookupEnd" : 1415358090102,
-           "se_value" : null,
-           "page_url" : "http://www.snowplowanalytics.com",
-           "etl_tags" : null,
-           "tr_orderid" : null,
-           "tr_state" : null,
-           "txn_id" : 41828,
-           "performance_timing_responseEnd" : 1415358090265,
-           "refr_source" : null,
-           "tr_country" : null,
-           "tr_city" : null,
-           "doc_charset" : null,
-           "event_fingerprint" : "e3dbfa9cca0412c3d4052863cefb547f",
-           "v_etl" : "serde-0.5.2"
-         }
-      }
-    """
-
     val result = (for {
       snowplowEvent <- EitherT.fromEither[Option](
         EventTransformer
           .transformWithInventory(Instances.tsvInput)
           .leftMap(errors => TransformationError(errors.mkString("\n  * "))))
-      indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory))
+      indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory, ".*".r))
     } yield indicativeEvent).value
 
     result shouldEqual Some(Right(expected.asObject.get))
@@ -262,6 +266,60 @@ class TransformationSpec extends Specification with ScalaCheck with Matchers {
   }
 
   def e2 = {
+
+    val result = (for {
+      snowplowEvent <- EitherT.fromEither[Option](
+        EventTransformer
+          .transformWithInventory(Instances.tsvInput)
+          .leftMap(errors => TransformationError(errors.mkString("\n  * "))))
+      indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory, "angry-birds".r))
+    } yield indicativeEvent).value
+
+    result shouldEqual Some(Right(expected.asObject.get))
+
+  }
+
+  def e3 = {
+
+    val result = (for {
+      snowplowEvent <- EitherT.fromEither[Option](
+        EventTransformer
+          .transformWithInventory(Instances.tsvInput)
+          .leftMap(errors => TransformationError(errors.mkString("\n  * "))))
+      indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory, "angry-cats".r))
+    } yield indicativeEvent).value
+
+    result must_== None
+  }
+
+  def e4 = {
+
+    val result = (for {
+      snowplowEvent <- EitherT.fromEither[Option](
+        EventTransformer
+          .transformWithInventory(Instances.tsvInput)
+          .leftMap(errors => TransformationError(errors.mkString("\n  * "))))
+      indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory, "^angry-.*".r))
+    } yield indicativeEvent).value
+
+    result shouldEqual Some(Right(expected.asObject.get))
+
+  }
+
+  def e5 = {
+
+    val result = (for {
+      snowplowEvent <- EitherT.fromEither[Option](
+        EventTransformer
+          .transformWithInventory(Instances.tsvInput)
+          .leftMap(errors => TransformationError(errors.mkString("\n  * "))))
+      indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory, "^.*-cats".r))
+    } yield indicativeEvent).value
+
+    result must_== None
+  }
+
+  def e6 = {
     val event = Instances.input
       .map {
         case (fieldName, _) if List("user_id", "domain_userid").contains(fieldName) => fieldName -> ""
@@ -275,14 +333,14 @@ class TransformationSpec extends Specification with ScalaCheck with Matchers {
         EventTransformer
           .transformWithInventory(event)
           .leftMap(errors => TransformationError(errors.mkString("\n  * "))))
-      indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory))
+      indicativeEvent <- EitherT(Transformer.transform(snowplowEvent.event, snowplowEvent.inventory, ".*".r))
     } yield indicativeEvent).value
 
     println(result)
     result must_== None
   }
 
-  def e3 = {
+  def e7 = {
     val uris = List(
       "iglu:com.getvero/delivered/jsonschema/1-0-0",
       "iglu:com.snowplowanalytics.snowplow.enrichments/weather_enrichment_config/jsonschema/1-0-0",
@@ -292,7 +350,7 @@ class TransformationSpec extends Specification with ScalaCheck with Matchers {
     Result.foreach(uris)(runTest)
   }
 
-  def e4 = {
+  def e8 = {
     val input = json"""
       {
         "foo": []
@@ -302,7 +360,7 @@ class TransformationSpec extends Specification with ScalaCheck with Matchers {
     FieldsExtraction.flattenJson(input, Set.empty) shouldEqual Map.empty
   }
 
-  def e5 = {
+  def e9 = {
     val input = json"""
       {
         "foo": {}
@@ -311,5 +369,4 @@ class TransformationSpec extends Specification with ScalaCheck with Matchers {
 
     FieldsExtraction.flattenJson(input, Set.empty) shouldEqual Map.empty
   }
-
 }


### PR DESCRIPTION
This PR has code and test coverage adding support for the filtering of events by app_id in the relay via the usage of an optional regex "APP_ID_REGEX" that can be defined as an environment variable.

Use Cases:
- Send only web events to Indicative
- Send only events from a specific site/property to Indicative
- Send production events and staging/testing events to different Indicative projects

All of these could be accomplished by creating multiple collectors / streams; however this allows for the flexibility of doing this with a single stream which is probably a more common setup.

This is the first time I have worked with Scala so it is very likely that my code is not as idiomatic as it could be. I am happy to refactor, or have someone else refactor the code if there are better ways to achieve what I did :) 

