### PR TITLE
Exclude null values from being included in Indicative event payload

### DIFF
--- a/src/main/scala/com/snowplowanalytics/indicative/FieldsExtraction.scala
+++ b/src/main/scala/com/snowplowanalytics/indicative/FieldsExtraction.scala
@@ -65,7 +65,9 @@ object FieldsExtraction {
       json.asArray
         .map(vector => if (vector.isEmpty) accumulator else iterate(key, vector.head, accumulator))
         .orElse(json.asObject.map(obj => iterateObject(key, obj.toList, accumulator)))
-        .getOrElse(accumulator.updated(key, json))
+        .getOrElse(json.asNull
+          .map(_ => accumulator)
+          .getOrElse(accumulator.updated(key, json)))
 
     iterate("", json, Map.empty)
   }

--- a/src/test/scala/com/snowplowanalytics/indicative/TransformationSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/indicative/TransformationSpec.scala
@@ -40,6 +40,7 @@ class TransformationSpec extends Specification with ScalaCheck with Matchers {
     constructBatchesOfEvents return events as too big                 $e9
     constructBatchesOfEvents return batches of the specified size     $e10
     constructBatchesOfEvents return batches according to payload size $e11
+    flattenJson should not parse null values as "null"                $e12
   """
 
   val apiKey = "API_KEY"
@@ -208,6 +209,16 @@ class TransformationSpec extends Specification with ScalaCheck with Matchers {
     )
     toSend shouldEqual List(elem, elem, elem, elem)
     tooBig shouldEqual Nil
+  }
+
+  def e12 = {
+    val input = json"""
+      {
+        "foo": null
+      }
+    """
+
+    FieldsExtraction.flattenJson(input, Set.empty) shouldEqual Map.empty
   }
 
 }


### PR DESCRIPTION
Hey all, I made a quick change to exclude null values from the payloads being sent to Indicative. This should reduce the size of the payload by quite a bit and hopefully increase the throughput of the relay.