### PR TITLE
Add option to configure Indicative's API URI via environment variable

### DIFF
--- a/src/main/scala/com/snowplowanalytics/indicative/LambdaHandler.scala
+++ b/src/main/scala/com/snowplowanalytics/indicative/LambdaHandler.scala
@@ -26,6 +26,7 @@ import Transformer.TransformationError
 class LambdaHandler {
   import LambdaHandler._
 
+  val indicativeUri: String = getConfig[String]("INDICATIVE_URI", Some(Relay.defaultIndicativeUri))(s => s)
   val apiKey: String = getConfig[String]("INDICATIVE_API_KEY")(s => s)
   val unusedEvents
     : List[String] = getConfig[List[String]]("UNUSED_EVENTS", Some(Filters.unusedEvents))(strToList(_)) // eg, `UNUSED_EVENTS=page_ping,app_heartbeat`
@@ -62,7 +63,7 @@ class LambdaHandler {
     }
 
     val sendEvents = toSend
-      .traverse(Relay.postEventBatch)
+      .traverse(Relay.postEventBatch(indicativeUri))
 
     (tooBigDebugging >>
       sendEvents

--- a/src/main/scala/com/snowplowanalytics/indicative/Relay.scala
+++ b/src/main/scala/com/snowplowanalytics/indicative/Relay.scala
@@ -21,13 +21,13 @@ import io.circe.Json
 
 object Relay {
 
-  private val indicativeUri = "https://api.indicative.com/service/event"
+  val defaultIndicativeUri = "https://api.indicative.com/service/event"
   private val relayHeaders = NonEmptyList.of(
     ("Indicative-Client", "Snowplow-Relay-" + BuildInfo.version),
     ("Content-Type", "application/json; charset=utf-8")
   )
 
-  def postSingleEvent(event: Json): IO[HttpResponse[String]] =
+  def postSingleEvent(indicativeUri: String)(event: Json): IO[HttpResponse[String]] =
     IO {
       Http(indicativeUri)
         .postData(event.noSpaces)
@@ -35,7 +35,7 @@ object Relay {
         .asString
     }
 
-  def postEventBatch(batchEvent: Json)(
+  def postEventBatch(indicativeUri: String)(batchEvent: Json)(
     implicit c: Clock[IO]
   ): IO[(HttpResponse[String], Long)] =
     for {


### PR DESCRIPTION
This PR introduces a new configuration option named `INDICATIVE_URI`. The default value of this option is the existing "https://api.indicative.com/service/event". In the case of high-throughput deployments, it may be necessary on Indicative's end to configure dedicated endpoints to handle the load.